### PR TITLE
added env variable, needed for openvas-scanner package

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,8 @@
 
 - name: install openvas
   shell: apt-get install -y -q openvas
+  environment:
+    HOME: /root
 
 - name: install nmap
   apt:


### PR DESCRIPTION
tested in staging, successfully installed openvas package:
```
root@ip-10-8-30-133:~# ps ax | grep open
 1260 ?        S      0:00 /usr/bin/python /usr/local/bin/cfn-init --region us-west-2 --stack vault-staging-01-openvas-01 --resource LaunchConfiguration --verbose --configsets ansible
12979 ?        Rs     0:33 openvassd: Reloaded 11800 of 49416 NVTs (23% / ETA: 02:04)
12980 ?        S      0:00 openvassd (Loading Handler)
13028 ?        SL     0:00 openvasmd
13043 ?        S      0:00 openvasmd: Reloading
13150 pts/0    S+     0:00 grep --color=auto open
root@ip-10-8-30-133:~# logout
```